### PR TITLE
Support react-leaflet 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,13 +32,10 @@
     "url": "https://github.com/TA-Geoforce/react-leaflet-bing-v2/issues"
   },
   "homepage": "https://github.com/TA-Geoforce/react-leaflet-bing-v2#readme",
-  "dependencies": {
-    "react-leaflet-google-v2": "^5.1.3"
-  },
   "peerDependencies": {
     "leaflet": "^1.7.1",
-    "react": "^15.0.0 || ^16.0.0 || ^17.0.0",
-    "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0",
+    "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
     "react-leaflet": "^4.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "leaflet": "^1.7.1",
     "react": "^15.0.0 || ^16.0.0 || ^17.0.0",
     "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0",
-    "react-leaflet": "^3.0.5"
+    "react-leaflet": "^4.2.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.3",

--- a/src/Bing.js
+++ b/src/Bing.js
@@ -2,11 +2,11 @@
 import { createLayerComponent } from '@react-leaflet/core';
 import {bingLayer} from './leaflet.bing';
 
-const createLeafletElement = (props) => {
+const createLeafletElement = (props, context) => {
 
     const instance = L.bingLayer(props.bingkey, props);
 
-    return { instance };
+    return { instance, context };
   }
 
 export default createLayerComponent(createLeafletElement);


### PR DESCRIPTION
Bump to react-leaflet v4.2.0 by adding context to `createLeafletElement`.
Update react-leaflet version in peer dependencies.
Add support to react 18 in package.json since i don't see any side effects.